### PR TITLE
Change hardcoded compton.conf

### DIFF
--- a/debian/compton.desktop
+++ b/debian/compton.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Compton
 Comment=Compton Compositor
-Exec=/bin/bash -c "seq 0 3 | xargs -l1 -I@ compton --config /etc/xdg/compton.conf -b -d :0.@"
+Exec=/bin/bash -c "seq 0 3 | xargs -l1 -I@ compton -b -d :0.@"
 Terminal=false
 Type=Application
 StartupNotify=false


### PR DESCRIPTION
Trying to override compton.conf on a user by user basis is not possible with the --config flag set to /etc/xdg/compton.conf. By removing it, compton will search ~/.config/compton.conf, ~/.compton.conf, then under $XDG_CONFIG_DIRS (which includes /etc/xdg).

I needed to add VirtualBox to the shadow-exclude section of compton.conf (it dims the screen when in fullscreen mode) and realized it wasn't using my ~/.config/compton.conf.
